### PR TITLE
chore: Update GitHub App credentials in workflow

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -16,8 +16,8 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.CZI_RELEASE_PLEASE_APP_ID }}
-          private-key: ${{ secrets.CZI_RELEASE_PLEASE_PK }}
+          app-id: ${{ secrets.GH_ACTIONS_HELPER_APP_ID }}
+          private-key: ${{ secrets.GH_ACTIONS_HELPER_PK }}
 
       - name: release please
         uses: googleapis/release-please-action@v4


### PR DESCRIPTION
`CZI_RELEASE_PLEASE_APP_ID` and `CZI_RELEASE_PLEASE_PK` will be removed in favor of `GH_ACTIONS_HELPER_*`