### PR TITLE
chore: Change postStackDetails to 'comment' in staging workflow

### DIFF
--- a/.github/workflows/argus-stack-staging-upsert.yaml
+++ b/.github/workflows/argus-stack-staging-upsert.yaml
@@ -32,4 +32,4 @@ jobs:
           appName: copick-server
           envName: staging
           waitForDeploymentSeconds: 300
-          postStackDetails: false
+          postStackDetails: comment


### PR DESCRIPTION
Makes the staging stack manager action post a comment to the release PR with staging stack details